### PR TITLE
Fix cursor jumping when moving really fast

### DIFF
--- a/clockworkpi/uconsole/glider.c
+++ b/clockworkpi/uconsole/glider.c
@@ -45,7 +45,13 @@ int8_t glider_glide(glider_t* gr, uint8_t delta) {
   // Use simple cast instead of floorf/ceilf: casting to int truncates toward zero,
   // which equals floor for positive values and ceil for negative values — matching previous logic.
   if (gr->error >= 1.0f || gr->error <= -1.0f) {
-    distance = (int8_t)gr->error;
+    if (gr->error > 127.0f) {
+      distance = 127;
+    } else if (gr->error < -127.0f) {
+      distance = -127;
+    } else {
+      distance = (int8_t)gr->error;
+    }
   }
 
   // Remove the integer part we are reporting, keep the remainder in gr->error


### PR DESCRIPTION
When the movement speed is high, the accumulated error can exceed the range of an 8-bit signed integer (-128 to 127). For example, if gr->error accumulates to 130, casting it to int8_t results in -126, causing the cursor to jump in the opposite direction. 

This patch should clamp the distance value to the valid range of int8_t (specifically -127 to 127). The remaining distance is kept in the error buffer and will be processed in subsequent reports, ensuring smooth movement without overflow artifacts.