### PR TITLE
Clear out the Magic Value that Prevent the loading the firmware in DFU mode

### DIFF
--- a/clockworkpi/uconsole/uconsole.c
+++ b/clockworkpi/uconsole/uconsole.c
@@ -1,0 +1,31 @@
+#include "quantum.h"
+
+// Helper to safely clear the backup register
+void clear_bootloader_flag(void) {
+    // 1. Enable power and backup interface clocks
+    RCC->APB1ENR |= (RCC_APB1ENR_PWREN | RCC_APB1ENR_BKPEN);
+
+    // 2. Enable access to the backup registers
+    PWR->CR |= PWR_CR_DBP;
+
+    // 3. Clear the magic value in BKP_DR10
+    BKP->DR10 = 0;
+
+    // 4. Disable backup domain access again
+    PWR->CR &= ~PWR_CR_DBP;
+}
+
+void keyboard_pre_init_kb(void) {
+    clear_bootloader_flag();
+    keyboard_pre_init_user();
+}
+
+void mcu_reset(void) {
+    clear_bootloader_flag();
+    NVIC_SystemReset();
+}
+
+void bootloader_jump(void) {
+    clear_bootloader_flag();
+    NVIC_SystemReset();
+}


### PR DESCRIPTION
By default, QMK writes a specific flag RTC_BOOTLOADER_JUST_UPLOADED to the backup register (DR10) when we restart the keyboard (e.g., via a macro or command).
This flag tells the stm32duino bootloader to skip its startup wait time and jump immediately to the firmware application.

By removing this write by overriding mcu_reset in `uconsole.c`, the behavior will now be:

- Soft Reset: When QMK resets, it will not set the "skip" flag.
- Bootloader: The bootloader will run, see no flag, and default to its standard behavior: it will wait for a short period (typically ~3-5 seconds) to see if you want to flash a new program (this is the "checking" phase). This means we can still re-flash the firmware, but we may have shorter window to operate. 
- Load Firmware: Once the timeout expires and no upload occurs, the bootloader will verify the existing firmware and jump to it.

This should align to the original stock firmware behaviour, and it should be a reasonable workaround  for power surge #10  