### PR TITLE
Patch grab bag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+clockworkpi_uconsole_default.bin
+qmk_firmware

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+#!/usr/bin/env -S make -f
+
+clockworkpi_uconsole_default.bin: qmk_firmware/.build/clockworkpi_uconsole_default.bin
+	mv qmk_firmware/.build/clockworkpi_uconsole_default.bin $@
+
+qmk_firmware/.build/clockworkpi_uconsole_default.bin: qmk_firmware
+	sh -c 'cd qmk_firmware; qmk compile -kb clockworkpi/uconsole -km default'
+
+qmk_firmware:
+	rm -rf $@.tmp
+	git clone --depth 1 https://github.com/qmk/qmk_firmware.git $@.tmp
+	git -C qmk_firmware.tmp submodule sync --recursive
+	git -C qmk_firmware.tmp submodule update --init --recursive
+	mv $@.tmp $@
+	ln -s $(PWD)/clockworkpi $(PWD)/qmk_firmware/keyboards/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,20 @@
 #!/usr/bin/env -S make -f
 
+SUDO = sudo
+USB_ID = 1eaf:0003
+
+.PHONY: default
+default: clockworkpi_uconsole_default.bin
+
+.PHONY: reflash
+reflash: clockworkpi_uconsole_default.bin
+	# dfu-util exits nonzero even without errors
+	sh -c '$(SUDO) dfu-util -w -d $(USB_ID) -a 2 -D clockworkpi_uconsole_default.bin -R || true'
+
 clockworkpi_uconsole_default.bin: qmk_firmware/.build/clockworkpi_uconsole_default.bin
 	mv qmk_firmware/.build/clockworkpi_uconsole_default.bin $@
 
-qmk_firmware/.build/clockworkpi_uconsole_default.bin: qmk_firmware
+qmk_firmware/.build/clockworkpi_uconsole_default.bin: clockworkpi/uconsole/keymaps/default/keymap.c qmk_firmware
 	sh -c 'cd qmk_firmware; qmk compile -kb clockworkpi/uconsole -km default'
 
 qmk_firmware:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Perfect for verifying your firmware installation and familiarizing yourself with
 ## 🎹 Special Key Behaviors
 
 * **Remapped A/B/X/Y in keyboard mode:**
+
 | Key    | Gamepad mode    | Keyboard mode
 |--------|-----------------|--------------
 | A      | `JS_0` (A)      | Execute (`KC_EXECUTE`)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Perfect for verifying your firmware installation and familiarizing yourself with
 
 ## 🎹 Special Key Behaviors
 
+* **Remapped A/B/X/Y in keyboard mode:**
+| Key    | Gamepad mode    | Keyboard mode
+|--------|-----------------|--------------
+| A      | `JS_0` (A)      | Execute (`KC_EXECUTE`)
+| B      | `JS_1` (B)      | Stop    (`KC_STOP`)
+| X      | `JS_2` (X)      | System Request (`KC_SYSTEM_REQUEST`)
+| Y      | `JS_3` (Y)      | Menu    (`KC_MENU`)
+| Select | `JS_4` (Select) | Select  (`KC_SELECT`)
+| Start  | `JS_5` (Start)  | Super   (`KC_LEFT_GUI`)
+
 * **Tap-Hold Keys (Letters, Numbers & Special Characters):** Most alphabetic keys, numbers, and special character keys support tap-hold functionality:
     * **Tap (< 200ms)** — Sends the lowercase letter or base character (e.g., `a`, `1`, `-`)
     * **Hold (≥ 200ms)** — Sends the uppercase letter or shifted symbol (e.g., `A`, `!`, `_`)

--- a/README.md
+++ b/README.md
@@ -119,19 +119,22 @@ If you already have QMK installed and want to update:
 
 2. **Enter bootloader mode:**
    
-   When you see `waiting for device, exit with ctrl-C`, press these three keys **simultaneously**:
-   
-   **`Left Alt` + `Right Alt` + `Start`**
+When dfu-util says `waiting for device, exit with ctrl-C`, press **Left Alt**,
+**Right Alt**, and **Start**, all **simultaneously**.
 
-   After installing the QMK firmware, bootload has 2-3 seconds window open for uploading firmware. Otherwise it will verify the existing firmware and functional as normal.
+After installing the QMK firmware, the bootloader has a 2-3 second window for
+uploading firmware. Otherwise it will verify the existing firmware and continue
+to function normally.
 
 ---
 
 ### 🆘 Recovery: Unbricking Your Keyboard
 
-In some rare cases, the keyboard did enter into the DFU mode, however, the firmware did not flash (keep showing waiting or ctrl+c to cancel) and keyboad is not responsive, try to reboot the OS then flash again.
+In some rare cases, the keyboard will have entered the DFU mode, but the
+firmware won't have flashed and the keyboard won't respond to input. If this
+happens, try rebooting the operating system and repeating the flashing steps.
 
-If this is bricked after reboot, Don't panic if your keyboard becomes unresponsive! Follow these steps to restore it:
+If the keyboard remains non-functional, don't panic! Follow these steps:
 
 1. **Connect the micro-USB cable** from your uConsole to the keyboard
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ the rest of the unit is unaffected.
 Before starting, ensure you have the necessary tools installed on your uConsole:
 
 1. **Install DFU utilities:**
-   ```bash
+   ```sh
    sudo apt install -y dfu-util
    ```
 
 2. **Download the original stock firmware package:**
-   ```bash
+   ```sh
    wget https://github.com/clockworkpi/uConsole/raw/master/Bin/uconsole_keyboard_flash.tar.gz
    tar zxvf uconsole_keyboard_flash.tar.gz
    cd uconsole_keyboard_flash
@@ -103,7 +103,7 @@ If you're upgrading from the original ClockworkPi firmware:
    Open `maple_upload` and change all delay values from `750` to `1500` milliseconds. This prevents "serial port not ready" errors.
 
 2. **Flash the firmware:**
-   ```bash
+   ```sh
    sudo ./maple_upload ttyACM0 2 1EAF:0003 clockworkpi_uconsole_default.bin
    ```
 ---
@@ -113,7 +113,7 @@ If you're upgrading from the original ClockworkPi firmware:
 If you already have QMK installed and want to update:
 
 1. **Run the DFU utility:**
-   ```bash
+   ```sh
    sudo dfu-util -w -d 1eaf:0003 -a 2 -D clockworkpi_uconsole_default.bin -R
    ```
 
@@ -141,7 +141,7 @@ If this is bricked after reboot, Don't panic if your keyboard becomes unresponsi
 ![Bootloading illustration](https://github.com/j1n6/qmk-uconsole/blob/main/images/uconsole%20keyboard%20bootloading.jpeg?raw=true)
 
 3. **Flash the stock firmware:**
-   ```bash
+   ```sh
    cd uconsole_keyboard_flash
    sudo ./flash
    ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ This provides a quick two-state toggle for precise pointer adjustments.
 
 ## 🎯 Installation Guide
 
-**⚠️ WARNING:** Use SSH or an external keyboard when performing these operations. In case of issues, you'll still be able to interact with the device to re-flash or troubleshoot.
+**⚠️ WARNING:**
+Don't install a firmware image without another input method, like an external
+keyboard or SSH connection, or you won't have any way to fix it if it fails.
+The uConsole keyboard is an independent USB device, so even if it has issues
+the rest of the unit is unaffected.
 
 ### Prerequisites
 

--- a/clockworkpi/uconsole/keymaps/default/keymap.c
+++ b/clockworkpi/uconsole/keymaps/default/keymap.c
@@ -74,7 +74,7 @@ const key_override_t vol_key_override =
 
 const key_override_t *key_overrides[] = {&vol_key_override};
 
-const uint16_t PROGMEM bootloader_combo[] = {KC_LALT, KC_RALT, JS_5, COMBO_END};
+const uint16_t PROGMEM bootloader_combo[] = {KC_LALT, KC_RALT, KC_LGUI, COMBO_END};
 combo_t key_combos[] = {COMBO(bootloader_combo, QK_BOOT)};
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
@@ -148,18 +148,19 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /*
      * Layer 2: Gamepad (Toggled by Fn+G)
      *
-     *   (JS_L)           (   ) (   )          (   ) (   )
-     * (JS_U) (JS_D)                             (   ) (   )
+     *   (JS_L)           (   ) (   )          ( Y ) ( X )
+     * (JS_U) (JS_D)                             ( B ) ( A )
      *   (JS_R)                                   (   )
      *
+     * (   )(Sel)(Sta)     (   )(   )(   )(   )(   )(   )(   )
      * [Note: D-pad keys mapped to Joystick Axis]
      */
     [LY2] = LAYOUT(
-        JS_LEFT, JS_RGHT, JS_UP,   JS_DOWN, _______, _______, _______, _______,
+        JS_LEFT, JS_RGHT, JS_UP,   JS_DOWN, JS_0,    JS_1,    JS_2,    JS_3,
         _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______,
 
-        _______, _______, _______, _______, _______, _______, _______, _______,
+        JS_4,    JS_5,    _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______,
         _______, _______, _______, _______, _______, _______, _______, _______,
@@ -305,7 +306,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case MO(LY1):
       // Fn: only perform normal layer switching; do not toggle scroll mode
       return true;  // Allow normal layer switching to continue
-    case JS_4:
+    case KC_SELECT: case JS_4:
       // Select key enables scroll mode while held (preserve tap behavior)
       select_button_pressed = record->event.pressed;
       return true;

--- a/clockworkpi/uconsole/keymaps/default/keymap.c
+++ b/clockworkpi/uconsole/keymaps/default/keymap.c
@@ -94,16 +94,16 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      *
      */
     [LY0] = LAYOUT(
-	/* JS_0 A -> Execute
-	 * JS_1 B -> Stop
-	 * JS_2 Y -> Menu
-	 * JS_3 X -> SysRq */   // formerly JS_0,    JS_1,    JS_2,    JS_3,
+        /* JS_0 A -> Execute
+         * JS_1 B -> Stop
+         * JS_2 Y -> Menu
+         * JS_3 X -> SysRq */   // formerly JS_0,    JS_1,    JS_2,    JS_3,
         KC_UP,   KC_DOWN, KC_LEFT, KC_RGHT, KC_EXEC, KC_STOP, KC_SYRQ, KC_MENU,
         KC_LSFT, KC_RSFT, KC_LCTL, KC_RCTL, KC_LALT, MS_BTN1, KC_RALT, MS_BTN2,
         MS_BTN3, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
 
-	/* JS_4 Select -> (Keyboard) Select
-	 * JS_5 Start  -> Left GUI */
+        /* JS_4 Select -> (Keyboard) Select
+         * JS_5 Start  -> Left GUI */
         KC_SELECT, KC_LGUI, KC_VOLD, LH_GRV, LH_LBRC, LH_RBRC, LH_MINS, LH_EQL,
         LH_1,      LH_2,    LH_3,    LH_4,    LH_5,    LH_6,    LH_7,    LH_8,
         LH_9,      LH_0,    KC_ESC,  KC_TAB,  KC_NO,   KC_NO,   KC_NO,   KC_NO,

--- a/clockworkpi/uconsole/keymaps/default/keymap.c
+++ b/clockworkpi/uconsole/keymaps/default/keymap.c
@@ -94,18 +94,24 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      *
      */
     [LY0] = LAYOUT(
-        KC_UP,   KC_DOWN, KC_LEFT, KC_RGHT, JS_0,    JS_1,    JS_2,    JS_3,
+	/* JS_0 A -> Execute
+	 * JS_1 B -> Stop
+	 * JS_3 Y -> Menu
+	 * JS_2 X -> SysRq */   // formerly JS_0,    JS_1,    JS_2,    JS_3,
+        KC_UP,   KC_DOWN, KC_LEFT, KC_RGHT, KC_EXEC, KC_STOP, KC_SYRQ, KC_MENU,
         KC_LSFT, KC_RSFT, KC_LCTL, KC_RCTL, KC_LALT, MS_BTN1, KC_RALT, MS_BTN2,
         MS_BTN3, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,
 
-        JS_4,    JS_5,    KC_VOLD, LH_GRV,  LH_LBRC, LH_RBRC, LH_MINS, LH_EQL,
-        LH_1,    LH_2,    LH_3,    LH_4,    LH_5,    LH_6,    LH_7,    LH_8,
-        LH_9,    LH_0,    KC_ESC,  KC_TAB,  KC_NO,   KC_NO,   KC_NO,   KC_NO,
-        LH_Q,    LH_W,    LH_E,    LH_R,    LH_T,    LH_Y,    LH_U,    LH_I,
-        LH_O,    LH_P,    LH_A,    LH_S,    LH_D,    LH_F,    LH_G,    LH_H,
-        LH_J,    LH_K,    LH_L,    LH_Z,    LH_X,    LH_C,    LH_V,    LH_B,
-        LH_N,    LH_M,    LH_COMM, LH_DOT,  LH_SLSH, LH_BSLS, LH_SCLN, LH_QUOT,
-        KC_BSPC, KC_ENT,  MO(LY1), MO(LY1), KC_SPC,  KC_NO,   KC_NO,   KC_NO
+	/* JS_4 Select -> (Keyboard) Select
+	 * JS_5 Start  -> Left GUI */
+        KC_SELECT, KC_LGUI, KC_VOLD, LH_GRV, LH_LBRC, LH_RBRC, LH_MINS, LH_EQL,
+        LH_1,      LH_2,    LH_3,    LH_4,    LH_5,    LH_6,    LH_7,    LH_8,
+        LH_9,      LH_0,    KC_ESC,  KC_TAB,  KC_NO,   KC_NO,   KC_NO,   KC_NO,
+        LH_Q,      LH_W,    LH_E,    LH_R,    LH_T,    LH_Y,    LH_U,    LH_I,
+        LH_O,      LH_P,    LH_A,    LH_S,    LH_D,    LH_F,    LH_G,    LH_H,
+        LH_J,      LH_K,    LH_L,    LH_Z,    LH_X,    LH_C,    LH_V,    LH_B,
+        LH_N,      LH_M,    LH_COMM, LH_DOT,  LH_SLSH, LH_BSLS, LH_SCLN, LH_QUOT,
+        KC_BSPC,   KC_ENT,  MO(LY1), MO(LY1), KC_SPC,  KC_NO,   KC_NO,   KC_NO
     ),
 
     /*

--- a/clockworkpi/uconsole/keymaps/default/keymap.c
+++ b/clockworkpi/uconsole/keymaps/default/keymap.c
@@ -96,8 +96,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [LY0] = LAYOUT(
 	/* JS_0 A -> Execute
 	 * JS_1 B -> Stop
-	 * JS_3 Y -> Menu
-	 * JS_2 X -> SysRq */   // formerly JS_0,    JS_1,    JS_2,    JS_3,
+	 * JS_2 Y -> Menu
+	 * JS_3 X -> SysRq */   // formerly JS_0,    JS_1,    JS_2,    JS_3,
         KC_UP,   KC_DOWN, KC_LEFT, KC_RGHT, KC_EXEC, KC_STOP, KC_SYRQ, KC_MENU,
         KC_LSFT, KC_RSFT, KC_LCTL, KC_RCTL, KC_LALT, MS_BTN1, KC_RALT, MS_BTN2,
         MS_BTN3, KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,   KC_NO,


### PR DESCRIPTION
- You can now run `make` in the project directory to build the QMK firmware locally, and `make reflash` to proceed directly to flashing.
- Light README editing for easier reading; some grammar and phrasing changes.

And of course the most potentially controversial change:
- Remaps A/B/X/Y/Select/Start in keypad mode to various keys not otherwise available on the keymap.

There were a lot of keys they could have been, like modifiers or special functions, but I wanted to add keys not already on the keymap:

- `KC_EXECUTE`: Can be remapped everywhere, but already indicates a "Go", like the A button in gaming.
- `KC_STOP`: Can be remapped everywhere, but already indicates a "Cancel", like the B button in gaming.
- `KC_SYSTEM_REQUEST`: Useful for Linux development and one of the few keys on 104-key keyboards that doesn't appear on the uConsole keyboard.
- `KC_MENU`: Another 104-key that doesn't otherwise appear.
- `KC_SELECT`: An obvious choice for the Select key.
- `KC_LEFT_GUI`: The most obvious missing modifier from other keyboards. As Alt+Alt+Super is meaningless everywhere (so DFU doesn't conflict) Start felt like a good place to put this.

I think the only remaining 104-keys not on the keyboard are Scroll Lock and Insert, which are both toggled keys that are notorious for confusing beginners. I figured those who want them badly enough probably know how to remap the existing inputs.