### PR TITLE
Remove the factory reset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Perfect for verifying your firmware installation and familiarizing yourself with
       - The setting persists across power cycles via EEPROM storage
       - When disabled: keys behave normally (single key press/release)
       - When enabled: timing-based tap-hold behavior applies
-    * **Factory Reset:** Press **Fn+C** to reset EEPROM to factory defaults
     * **Note:** Game keys (X, Y, A, B, Select, Start) and direction keys (Up, Down, Left, Right) do NOT have tap-hold behavior to preserve their functionality for gaming
 
 * **Trackball Scrolling:** Hold the **Select** key and move the trackball to scroll.

--- a/clockworkpi/uconsole/keymaps/default/keymap.c
+++ b/clockworkpi/uconsole/keymaps/default/keymap.c
@@ -125,9 +125,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
      * (   )(F1 )(F2 )(F3 )(F4 )(F5 )(F6 )(F7 )(F8 )(F9 )(F10)(Del)
      * (Cap)(   )(   )(   )(   )(   )(   )(PgU)(Ins)(   )(   )
      * (   )(   )(   )(   )(THd)(Tg2)(Hom)(End)(PgD)(   )(   )(   )
-     * (Hom)(PgD)(   )(   )(   )(Clr)(   )(   )
+     * (Hom)(PgD)(   )(   )(   )(   )(   )(   )
      * (   )(   )(Cmd)(      BlStp       )(Cmd)(   )(  )
-     * THd = Tap-Hold Toggle, Clr = EEPROM Clear
+     * THd = Tap-Hold Toggle
      */
 
     [LY1] = LAYOUT(
@@ -140,7 +140,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         KC_F9,   KC_F10,  KB_LOCK, KC_CAPS, _______, _______, _______, _______,
         _______, _______, _______, _______, KB_TAP_HOLD, _______, KC_PGUP, KC_INS,
         _______, _______, _______, _______, _______, _______, TG(LY2), KC_HOME,
-        KC_END,  KC_PGDN, _______, _______, _______, EE_CLR,  _______, _______,
+        KC_END,  KC_PGDN, _______, _______, _______, _______, _______, _______,
         _______, _______, KC_BRID, KC_BRIU, _______, _______, _______, _______,
         KC_DEL,  _______, _______, _______, BL_STEP, _______, _______, _______
     ),


### PR DESCRIPTION
Reviewing the issue raised in #22 
Removing the FN+C function because it is useful when QMK has complex settings for larger profile keyboards. FN+C serves no purpose other than development & testing the firmware features. 